### PR TITLE
Use editor.api.js entrypoint for monaco-editor types

### DIFF
--- a/monaco-editor.d.ts
+++ b/monaco-editor.d.ts
@@ -1,6 +1,6 @@
 // One of these modules should exist, but not the other.
 
 // @ts-ignore
-export * from 'monaco-editor'
+export * from 'monaco-editor/esm/vs/editor/editor.api.js'
 // @ts-ignore
 export * from 'monaco-editor-core'

--- a/test.ts
+++ b/test.ts
@@ -18,3 +18,20 @@ severity = MarkerSeverity.Error
 
 /// @ts-expect-error ensure namespaces can’t be used as values.
 editor.createModel('')
+
+// Ensure MonacoEditor has core API surface
+declare const m: MonacoEditor
+m.editor
+m.languages
+
+// Ensure contribution namespaces from editor.main are not on MonacoEditor
+// @ts-expect-error
+m.css
+// @ts-expect-error
+m.html
+// @ts-expect-error
+m.json
+// @ts-expect-error
+m.typescript
+// @ts-expect-error
+m.createWebWorker


### PR DESCRIPTION
Re-exports from `monaco-editor/esm/vs/editor/editor.api.js` instead of `monaco-editor` so that `MonacoEditor` aligns with the type surface exposed by `@monaco-editor/react`.

Fixes the type mismatch reported in https://github.com/remcohaszing/monaco-yaml/issues/281.

Per https://github.com/remcohaszing/monaco-yaml/issues/281#issuecomment-2851783083.